### PR TITLE
Add project overview doc and fix directory setup naming

### DIFF
--- a/docs/00-table-of-contents.md
+++ b/docs/00-table-of-contents.md
@@ -12,7 +12,7 @@ Copy this to `docs/00-table-of-contents.md` (or `README.md` in `/docs/`).
 
 | Step | Area/Service           | Documentation File                | Complete? |
 |------|------------------------|-----------------------------------|-----------|
-|  1   | Project Overview & Goals   | [01-overview-goals.md](./01-overview-goals.md)         | [ ]       |
+|  1   | Project Overview & Goals   | [01-overview-goals.md](./01-overview-goals.md)         | [x]       |
 |  2   | Directory Structure & Setup| [02-directory-setup.md](./02-directory-setup.md)       | [ ]       |
 |  3   | Dockerizing Backend (API)  | [03-dockerizing-api.md](./03-dockerizing-api.md)       | [ ]       |
 |  4   | Docker Compose Orchestration | [04-docker-compose-orchestration.md](./04-docker-compose-orchestration.md) | [ ]       |

--- a/docs/01-overview-goals.md
+++ b/docs/01-overview-goals.md
@@ -1,0 +1,26 @@
+# 01. Project Overview & Goals
+
+## Purpose
+This document outlines the vision and overall objectives of the hosting platform. It serves as a starting point for contributors who need a high-level understanding of what the project aims to achieve.
+
+## Vision
+We are building a modern, extensible hosting and orchestration platform for a TypeScript frontend and a Python FastAPI backend. The system should be modular, maintainable, and ready to evolve from local development to distributed or cloud deployments.
+
+## Key Goals
+- **Consistency** across environments using Docker for all services.
+- **Isolation** and clear separation of concerns between components.
+- **Extensibility** so new services and features can be added with minimal friction.
+- **Best practices** for security, scalability, and developer experience.
+- **Comprehensive documentation** accompanying every part of the stack.
+
+## Roadmap
+The project is organized into incremental steps. After setting goals, you will:
+1. Define the directory structure and initial setup.
+2. Dockerize backend services and orchestrate them with Docker Compose.
+3. Configure NGINX as a reverse proxy.
+4. Manage environment variables and secrets securely.
+5. Configure persistent volumes and service networking.
+6. Establish monitoring, logging, scaling, and additional Rust utilities.
+
+## Next Step
+Continue to [02-directory-setup.md](./02-directory-setup.md) to learn about the monorepo layout and how to bootstrap the project.

--- a/docs/02-directory-setup.md
+++ b/docs/02-directory-setup.md
@@ -1,9 +1,9 @@
-Awesome! Here’s a **complete, well-structured draft** for **`01-monorepo-structure.md`**—with copy-paste-ready content and prompts for tailoring to your project.
+Awesome! Here’s a **complete, well-structured draft** for **`02-directory-setup.md`**—with copy-paste-ready content and prompts for tailoring to your project.
 
 ---
 
 ```md
-# 01. Monorepo Structure
+# 02. Directory Structure & Setup
 
 ## Purpose
 
@@ -34,7 +34,7 @@ my-hosting-platform/
 ├── nginx/
 │   └── nginx.conf            # Reverse proxy config
 ├── docs/                     # Project documentation (this folder)
-│   ├── 01-monorepo-structure.md
+│   ├── 02-directory-setup.md
 │   └── ... (other docs)
 ├── docker-compose.yml        # Multi-app orchestration config
 ├── .env                      # Global environment variables & secrets
@@ -118,7 +118,7 @@ High-level introduction, setup guide, and developer quickstart.
 
 **How to use:**
 
-* Copy into `docs/01-monorepo-structure.md`
+* Copy into `docs/02-directory-setup.md`
 * Tailor folder/app descriptions if you add more services
 * Add project-specific tips or diagrams if desired
 


### PR DESCRIPTION
## Summary
- add project overview & goals document
- rename `01-monorepo-structure.md` to `02-directory-setup.md`
- update numbering in directory setup doc
- mark overview doc complete in table of contents

## Testing
- `git diff --name-status --cached`


------
https://chatgpt.com/codex/tasks/task_e_684d040c6170832390f4d860232c3fb8