### PR TITLE
Initialize project and clarify build steps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Copy to .env and set real values
+POSTGRES_USER=myuser
+POSTGRES_PASSWORD=mypassword
+POSTGRES_DB=mydb

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,11 @@ Before planning or coding, open `docs/00-table-of-contents.md` and locate the fi
 Carefully review the code and documentation for the previous item to ensure it is fully complete;
 if anything is missing, finish that work before moving on.
 
+### Build While Documenting
+- Each entry in the table of contents represents real work to implement in this repository.
+- As you write or update documentation, create the corresponding files, directories, and configuration.
+- Only mark an item complete after its implementation exists and runs as described.
+
 ---
 
 ## Project Vision

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# Hosting Platform
+
+This repository contains a minimal monorepo for experimenting with a Docker-based hosting platform.
+It includes a TypeScript frontend, a FastAPI backend, and infrastructure configuration.

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 8000
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+def read_root():
+    return {"hello": "world"}

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,13 @@
+# Stage 1: Build frontend assets
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# Stage 2: Serve with NGINX
+FROM nginx:alpine
+COPY --from=builder /app/dist /usr/share/nginx/html
+EXPOSE 3000
+CMD ["nginx", "-g", "daemon off;"]

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Web App</title>
+  </head>
+  <body>
+    <h1>Hello from the web app</h1>
+  </body>
+</html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "web",
+  "version": "0.1.0",
+  "scripts": {
+    "build": "mkdir -p dist && cp index.html dist/index.html"
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: "3.8"
+
+services:
+  web:
+    build: ./apps/web
+    container_name: web
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=production
+
+  api:
+    build: ./apps/api
+    container_name: api
+    ports:
+      - "8000:8000"
+    environment:
+      - ENV=production
+
+  db:
+    image: postgres:16
+    container_name: db
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  nginx:
+    image: nginx:latest
+    container_name: nginx
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - web
+      - api
+
+volumes:
+  db_data:

--- a/docs/00-table-of-contents.md
+++ b/docs/00-table-of-contents.md
@@ -3,7 +3,7 @@
 
 | Step | Area/Service | Documentation File | Complete? |
 |------|--------------|--------------------|-----------|
-| 1 | Project Overview & Goals | [01-overview-goals.md](./01-overview-goals.md) | [x] |
+| 1 | Project Overview & Goals | [01-overview-goals.md](./01-overview-goals.md) | [ ] |
 | 2 | Directory Structure & Setup | [02-directory-setup.md](./02-directory-setup.md) | [ ] |
 | 3 | Dockerizing Backend (API) | [03-dockerizing-api.md](./03-dockerizing-api.md) | [ ] |
 | 4 | Docker Compose Orchestration | [04-docker-compose-orchestration.md](./04-docker-compose-orchestration.md) | [ ] |

--- a/docs/02-directory-setup.md
+++ b/docs/02-directory-setup.md
@@ -1,8 +1,3 @@
-Awesome! Here’s a **complete, well-structured draft** for **`02-directory-setup.md`**—with copy-paste-ready content and prompts for tailoring to your project.
-
----
-
-```md
 # 02. Directory Structure & Setup
 
 ## Purpose
@@ -110,15 +105,4 @@ High-level introduction, setup guide, and developer quickstart.
 
 - [ ] [02-dockerizing-web.md](./02-dockerizing-web.md): Dockerizing the frontend (Vite) app.
 - [ ] [03-dockerizing-api.md](./03-dockerizing-api.md): Dockerizing the backend (FastAPI) app.
-
----
-```
-
----
-
-**How to use:**
-
-* Copy into `docs/02-directory-setup.md`
-* Tailor folder/app descriptions if you add more services
-* Add project-specific tips or diagrams if desired
 

--- a/docs/02-dockerizing-web.md
+++ b/docs/02-dockerizing-web.md
@@ -1,8 +1,3 @@
-Great! Here’s a **detailed, production-ready template for `02-dockerizing-web.md`**—your Vite/React frontend.
-
----
-
-````md
 # 02. Dockerizing the Frontend (Vite/React)
 
 ## Purpose
@@ -43,7 +38,7 @@ RUN npm run build
 FROM nginx:alpine
 COPY --from=builder /app/dist /usr/share/nginx/html
 EXPOSE 3000
-````
+```
 
 * **Why this pattern?**
 
@@ -118,15 +113,3 @@ services:
 ## Next Steps
 
 * [ ] [03-dockerizing-api.md](./03-dockerizing-api.md): Dockerizing the backend (FastAPI) app.
-
-```
-
----
-
-**How to use:**  
-- Copy/paste into `docs/02-dockerizing-web.md`.
-- Update `myapp-web` image name as you like.
-- Adjust “Development Tips” section if you have a custom workflow.
-
-**Ready for step 3 (Dockerizing API), or want a tweak to this one?**
-```

--- a/docs/03-dockerizing-api.md
+++ b/docs/03-dockerizing-api.md
@@ -1,8 +1,3 @@
-Perfect! Here is a **detailed, practical template for `03-dockerizing-api.md`**—for your Python FastAPI backend.
-
----
-
-````md
 # 03. Dockerizing the Backend (FastAPI/Python)
 
 ## Purpose
@@ -46,7 +41,7 @@ EXPOSE 8000
 
 # Run Uvicorn (production-ready ASGI server)
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
-````
+```
 
 * **main\:app** assumes your entrypoint is `main.py` and your FastAPI object is named `app`. Adjust if needed.
 * **requirements.txt** should contain all Python dependencies (including `fastapi` and `uvicorn`).
@@ -128,15 +123,3 @@ services:
 ## Next Steps
 
 * [ ] [04-docker-compose-orchestration.md](./04-docker-compose-orchestration.md): Orchestrating all services with Docker Compose.
-
-```
-
----
-
-**How to use:**
-- Copy into `docs/03-dockerizing-api.md`
-- Adjust `main:app` and requirements as needed for your codebase.
-- Add any extra dependencies, DB connection instructions, or local dev notes for your setup.
-
-**Ready for step 4 (Docker Compose orchestration)?**
-```

--- a/docs/04-docker-compose-orchestration.md
+++ b/docs/04-docker-compose-orchestration.md
@@ -1,8 +1,3 @@
-Great! Here’s a **detailed template for `04-docker-compose-orchestration.md`**, explaining how to orchestrate all your services (frontend, backend, DB, proxy) using Docker Compose.
-
----
-
-```md
 # 04. Docker Compose Orchestration
 
 ## Purpose
@@ -37,7 +32,7 @@ my-hosting-platform/
 │   └── db/
 └── ...
 
-````
+```
 
 ---
 
@@ -88,7 +83,7 @@ services:
 
 volumes:
   db_data:
-````
+```
 
 ---
 
@@ -176,15 +171,3 @@ volumes:
 * [ ] [05-nginx-reverse-proxy.md](./05-nginx-reverse-proxy.md): Setting up the reverse proxy for routing.
 * [ ] [06-env-vars-secrets.md](./06-env-vars-secrets.md): Managing environment variables and secrets.
 
----
-
-```
-
----
-
-**How to use:**  
-- Copy this into `docs/04-docker-compose-orchestration.md`
-- Adjust service names/paths/ports as needed for your actual project.
-
-**Ready for step 5 (NGINX Reverse Proxy)?**
-```

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,12 @@
+events {}
+http {
+    server {
+        listen 80;
+        location / {
+            proxy_pass http://web:3000;
+        }
+        location /api/ {
+            proxy_pass http://api:8000/;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- instruct agent to implement each step when documenting
- reset build checklist to show no steps complete
- create basic monorepo structure for web and API services
- add Dockerfiles and a docker-compose.yml for local orchestration
- include example environment file and minimal nginx config

## Testing
- `python3 -m py_compile apps/api/main.py`
- `node --version`
- `docker --version` *(fails: command not found)*
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684d09a32fe88323bc45ec7824cc2af9