### PR TITLE
Add multi-language app support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 This repository contains a lightweight platform for hosting multiple fullstack applications. Each app defines its own Compose file externally and is reverse proxied through a single NGINX instance.
 
+Sample backends are provided for FastAPI, Express, NestJS and ASP.NET to demonstrate that any Dockerised language can be integrated.
+
 ## Usage
 
 1. Add YAML files under `compose/app-registry/` describing each app's domains and ports.
-2. Generate the NGINX configuration:
+2. Generate the NGINX configuration and reload the proxy:
    ```bash
-   python scripts/generate-nginx.py
+   python scripts/generate-nginx.py --reload
    ```
 3. Start the core services:
    ```bash

--- a/apps/csharp-api/Dockerfile
+++ b/apps/csharp-api/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY *.csproj ./
+RUN dotnet restore
+COPY . .
+RUN dotnet publish -c Release -o /app
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
+WORKDIR /app
+COPY --from=build /app .
+EXPOSE 5000
+ENTRYPOINT ["dotnet", "csharp-api.dll"]

--- a/apps/csharp-api/Program.cs
+++ b/apps/csharp-api/Program.cs
@@ -1,0 +1,6 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+app.MapGet("/", () => Results.Json(new { message = "Hello from ASP.NET" }));
+var port = Environment.GetEnvironmentVariable("PORT") ?? "5000";
+app.Urls.Add($"http://0.0.0.0:{port}");
+app.Run();

--- a/apps/csharp-api/csharp-api.csproj
+++ b/apps/csharp-api/csharp-api.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/apps/csharp-api/docker-compose.yml
+++ b/apps/csharp-api/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3.8"
+services:
+  csharp_api:
+    build: .
+    container_name: csharp_api
+    ports:
+      - "5000:5000"

--- a/apps/express/Dockerfile
+++ b/apps/express/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --production
+COPY . .
+EXPOSE 4000
+CMD ["npm", "start"]

--- a/apps/express/docker-compose.yml
+++ b/apps/express/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3.8"
+services:
+  express:
+    build: .
+    container_name: express
+    ports:
+      - "4000:4000"

--- a/apps/express/index.js
+++ b/apps/express/index.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const app = express();
+const port = process.env.PORT || 4000;
+app.get('/', (req, res) => {
+  res.json({ message: 'Hello from Express' });
+});
+app.listen(port, () => console.log(`Express app listening on port ${port}`));

--- a/apps/express/package.json
+++ b/apps/express/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "express-app",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/apps/nest/Dockerfile
+++ b/apps/nest/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json tsconfig.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=builder /app/package*.json ./
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+EXPOSE 4001
+CMD ["npm", "start"]

--- a/apps/nest/docker-compose.yml
+++ b/apps/nest/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3.8"
+services:
+  nest:
+    build: .
+    container_name: nest
+    ports:
+      - "4001:4001"

--- a/apps/nest/main.ts
+++ b/apps/nest/main.ts
@@ -1,0 +1,22 @@
+import { NestFactory } from '@nestjs/core';
+import { Module, Controller, Get } from '@nestjs/common';
+
+@Controller()
+class AppController {
+  @Get()
+  getRoot() {
+    return { message: 'Hello from NestJS' };
+  }
+}
+
+@Module({
+  controllers: [AppController],
+})
+class AppModule {}
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  const port = process.env.PORT || 4001;
+  await app.listen(port as number);
+}
+bootstrap();

--- a/apps/nest/package.json
+++ b/apps/nest/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "nest-app",
+  "version": "1.0.0",
+  "main": "dist/main.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/main.js"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.4"
+  }
+}

--- a/apps/nest/tsconfig.json
+++ b/apps/nest/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2017",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "outDir": "dist",
+    "strict": false
+  },
+  "include": ["main.ts"]
+}

--- a/compose/app-registry/csharp.yaml
+++ b/compose/app-registry/csharp.yaml
@@ -1,0 +1,8 @@
+name: csharp
+frontend:
+  port: 5000
+  domain: csharp.local
+backend:
+  port: 5000
+  domain: api.csharp.local
+compose_file: ../apps/csharp-api/docker-compose.yml

--- a/compose/app-registry/express.yaml
+++ b/compose/app-registry/express.yaml
@@ -1,0 +1,8 @@
+name: express
+frontend:
+  port: 4000
+  domain: express.local
+backend:
+  port: 4000
+  domain: api.express.local
+compose_file: ../apps/express/docker-compose.yml

--- a/compose/app-registry/nest.yaml
+++ b/compose/app-registry/nest.yaml
@@ -1,0 +1,8 @@
+name: nest
+frontend:
+  port: 4001
+  domain: nest.local
+backend:
+  port: 4001
+  domain: api.nest.local
+compose_file: ../apps/nest/docker-compose.yml

--- a/docs/20-multi-language-backends.md
+++ b/docs/20-multi-language-backends.md
@@ -1,0 +1,51 @@
+# 20. Hosting Multiple Language Backends
+
+## Purpose
+
+This guide explains how the platform can host APIs written in different languages. The
+sample apps in `apps/` demonstrate Python (FastAPI), Node.js (Express and NestJS), and
+C# (.NET) services. Each backend is containerised with its own `Dockerfile` and optional
+`docker-compose.yml` for local testing.
+
+## Directory Layout
+
+```
+apps/
+  api/           # FastAPI example
+  express/       # Node.js Express
+  nest/          # Node.js NestJS
+  csharp-api/    # ASP.NET minimal API
+```
+
+## General Steps
+
+1. Implement your backend using your language/framework of choice.
+2. Provide a `Dockerfile` that exposes the service on a configurable `PORT`.
+3. (Optional) Include a `docker-compose.yml` for local development.
+4. Add an entry under `compose/app-registry/` pointing to the compose file and desired domains.
+5. Regenerate `nginx.conf` and reload the proxy:
+   ```bash
+   python scripts/generate-nginx.py --reload
+   ```
+
+The registry-driven approach means any language can be supported as long as it is Dockerised.
+
+## Example Compose Entry
+
+```yaml
+name: express
+frontend:
+  port: 4000
+  domain: express.local
+backend:
+  port: 4000
+  domain: api.express.local
+compose_file: ../apps/express/docker-compose.yml
+```
+
+This configuration forwards `express.local` to the frontend container and `api.express.local`
+to the backend service once the compose file is launched separately.
+
+---
+
+With this scaffolding in place you can expand to additional languages or frameworks as needed.

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -105,9 +105,9 @@ This platform allows you to host multiple fullstack applications by referencing 
 ## Usage
 
 1. Create `compose/app-registry/*.yaml` entries for each app.
-2. Run the generator:
+2. Run the generator (optionally reload NGINX automatically):
    ```bash
-   python scripts/generate-nginx.py
+   python scripts/generate-nginx.py --reload
    ```
 3. Start the core platform (NGINX):
    ```bash
@@ -120,9 +120,14 @@ This platform allows you to host multiple fullstack applications by referencing 
 
 Apps will be reverse proxied by domain via NGINX.
 
+The sample apps demonstrate hosting FastAPI (Python), Express and NestJS (Node.js),
+and an ASP.NET minimal API. Any Dockerised backend can be added to the registry
+following the same pattern.
+
 ## Requirements
 - Docker & Docker Compose
 - Python (`pyyaml`, `jinja2`)
+- Node.js and the .NET SDK if you wish to build the example Node and C# apps locally
 
 ---
 

--- a/docs/hostingplan.md
+++ b/docs/hostingplan.md
@@ -14,6 +14,7 @@ This self-hosted platform is designed to serve as a lightweight PaaS. It allows 
 - ✅ Proxy frontend and backend domains using NGINX
 - ✅ Use a dynamic registry-based system to configure hosted apps
 - ✅ Keep the platform lightweight, modular, and extensible
+- ✅ Support backends written in Python, Node.js, and C#
 
 ---
 
@@ -62,9 +63,9 @@ compose_file: /home/youruser/code/my-apps/app1/docker-compose.yml
 
 ### 3. **Generate NGINX Config**
 
-Use Jinja2 templating and a script to convert the registry into a fully working `nginx.conf`:
+Use Jinja2 templating and a script to convert the registry into a fully working `nginx.conf` and reload NGINX if it is running:
 ```bash
-python scripts/generate-nginx.py
+python scripts/generate-nginx.py --reload
 ```
 This populates upstream and server blocks for all defined apps.
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -30,6 +30,7 @@ This checklist defines the **build order** of the platform. Each item represents
 | 18 | Rust: Metrics Exporter | [18-metrics-exporter.md](./18-metrics-exporter.md) | [x] |
 
 | 19 | Rust: Custom CLI Tool | [19-custom-cli-tool.md](./19-custom-cli-tool.md) | [x] |
+| 20 | Multi-Language Backends | [20-multi-language-backends.md](./20-multi-language-backends.md) | [x] |
 
 ---
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -3,6 +3,66 @@ events { worker_connections 1024; }
 
 http {
 
+  upstream express_frontend {
+    server express_frontend:4000;
+  }
+
+  upstream express_backend {
+    server express_backend:4000;
+  }
+
+  server {
+    listen 80;
+    server_name express.local;
+
+    location / {
+      proxy_pass http://express_frontend;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+    }
+  }
+
+  server {
+    listen 80;
+    server_name api.express.local;
+
+    location / {
+      proxy_pass http://express_backend;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+    }
+  }
+
+  upstream csharp_frontend {
+    server csharp_frontend:5000;
+  }
+
+  upstream csharp_backend {
+    server csharp_backend:5000;
+  }
+
+  server {
+    listen 80;
+    server_name csharp.local;
+
+    location / {
+      proxy_pass http://csharp_frontend;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+    }
+  }
+
+  server {
+    listen 80;
+    server_name api.csharp.local;
+
+    location / {
+      proxy_pass http://csharp_backend;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+    }
+  }
+
   upstream app1_frontend {
     server app1_frontend:3000;
   }
@@ -28,6 +88,36 @@ http {
 
     location / {
       proxy_pass http://app1_backend;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+    }
+  }
+
+  upstream nest_frontend {
+    server nest_frontend:4001;
+  }
+
+  upstream nest_backend {
+    server nest_backend:4001;
+  }
+
+  server {
+    listen 80;
+    server_name nest.local;
+
+    location / {
+      proxy_pass http://nest_frontend;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+    }
+  }
+
+  server {
+    listen 80;
+    server_name api.nest.local;
+
+    location / {
+      proxy_pass http://nest_backend;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
     }

--- a/scripts/generate-nginx.py
+++ b/scripts/generate-nginx.py
@@ -1,5 +1,8 @@
-import yaml
+import argparse
 import os
+import subprocess
+
+import yaml
 from jinja2 import Template
 
 REGISTRY_PATH = "compose/app-registry"
@@ -14,7 +17,30 @@ def load_registry():
                 apps.append(yaml.safe_load(f))
     return apps
 
-def main():
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate nginx.conf from app registry"
+    )
+    parser.add_argument(
+        "--reload",
+        action="store_true",
+        help="Reload the nginx container after updating the config",
+    )
+    return parser.parse_args()
+
+
+def reload_nginx() -> None:
+    try:
+        subprocess.run(
+            ["docker", "exec", "nginx", "nginx", "-s", "reload"], check=True
+        )
+        print("✅ NGINX reloaded")
+    except Exception as exc:
+        print(f"⚠️  Failed to reload NGINX: {exc}")
+
+
+def main() -> None:
+    args = parse_args()
     apps = load_registry()
 
     with open(TEMPLATE_PATH) as f:
@@ -26,6 +52,9 @@ def main():
         f.write(rendered)
 
     print(f"✅ nginx.conf updated with {len(apps)} app(s)")
+
+    if args.reload:
+        reload_nginx()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- add example Express, NestJS and C# apps with Dockerfiles
- document multi-language backends and update table of contents
- include registry entries for the new apps
- update generator script with --reload option
- update docs/README to mention new languages and dynamic reload

## Testing
- `python scripts/generate-nginx.py --reload` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d6f46b7408323b84ee7ebc769250b