### PR TITLE
Add multi-language backend scaffolds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fullstack App Hosting Platform
 
-This repository contains a lightweight platform for hosting multiple fullstack applications. Each app defines its own Compose file externally and is reverse proxied through a single NGINX instance.
+This repository contains a lightweight platform for hosting multiple fullstack applications. Each app defines its own Compose file externally and is reverse proxied through a single NGINX instance. The platform can proxy Python (FastAPI), Node.js (Express or NestJS), and even C# backends.
 
 ## Usage
 
@@ -13,10 +13,11 @@ This repository contains a lightweight platform for hosting multiple fullstack a
    ```bash
    docker-compose up -d --build
    ```
-4. Launch each application using its own Compose file:
+4. Launch each application using its own Compose file or let the helper script manage them for you:
    ```bash
-   docker compose -f /path/to/app/docker-compose.yml up -d
+   python scripts/launch_apps.py up
    ```
+   The script reads `compose/app-registry/*.yaml` and runs `docker compose` for each app.
 
 The apps will be accessible at the domains specified in the registry.
 

--- a/apps/csharp_api/Dockerfile
+++ b/apps/csharp_api/Dockerfile
@@ -1,0 +1,15 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 5000
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY csharp_api.csproj ./
+RUN dotnet restore
+COPY . .
+RUN dotnet publish -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "csharp_api.dll"]

--- a/apps/csharp_api/Program.cs
+++ b/apps/csharp_api/Program.cs
@@ -1,0 +1,6 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/", () => Results.Json(new { message = "Hello from ASP.NET Core" }));
+
+app.Run();

--- a/apps/csharp_api/csharp_api.csproj
+++ b/apps/csharp_api/csharp_api.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/apps/csharp_api/docker-compose.yml
+++ b/apps/csharp_api/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3.8"
+services:
+  csharp_backend:
+    build: .
+    ports:
+      - "5000:5000"

--- a/apps/express_api/Dockerfile
+++ b/apps/express_api/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install --production
+COPY . .
+EXPOSE 4000
+CMD ["node", "index.js"]

--- a/apps/express_api/docker-compose.yml
+++ b/apps/express_api/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3.8"
+services:
+  express_backend:
+    build: .
+    ports:
+      - "4000:4000"

--- a/apps/express_api/index.js
+++ b/apps/express_api/index.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const app = express();
+const port = process.env.PORT || 4000;
+
+app.get('/', (req, res) => {
+  res.json({ message: 'Hello from Express' });
+});
+
+app.listen(port, () => {
+  console.log(`Express server listening on ${port}`);
+});

--- a/apps/express_api/package.json
+++ b/apps/express_api/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "express_api",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/apps/nest_api/Dockerfile
+++ b/apps/nest_api/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package.json tsconfig.json ./
+RUN npm install
+COPY src ./src
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+COPY package.json ./
+RUN npm install --production
+EXPOSE 4001
+CMD ["node", "dist/main.js"]

--- a/apps/nest_api/docker-compose.yml
+++ b/apps/nest_api/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3.8"
+services:
+  nest_backend:
+    build: .
+    ports:
+      - "4001:4001"

--- a/apps/nest_api/package.json
+++ b/apps/nest_api/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "nest_api",
+  "version": "1.0.0",
+  "main": "dist/main.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/main.js"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.2.5",
+    "@nestjs/core": "^10.2.5",
+    "@nestjs/platform-express": "^10.2.5",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5"
+  }
+}

--- a/apps/nest_api/src/main.ts
+++ b/apps/nest_api/src/main.ts
@@ -1,0 +1,20 @@
+import { NestFactory } from '@nestjs/core';
+import { Module, Controller, Get } from '@nestjs/common';
+
+@Controller()
+class AppController {
+  @Get()
+  getRoot() {
+    return { message: 'Hello from NestJS' };
+  }
+}
+
+@Module({ controllers: [AppController] })
+class AppModule {}
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(process.env.PORT || 4001);
+}
+
+bootstrap();

--- a/apps/nest_api/tsconfig.json
+++ b/apps/nest_api/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2017",
+    "outDir": "dist",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  },
+  "include": ["src/**/*"]
+}

--- a/compose/app-registry/csharp_api.yaml
+++ b/compose/app-registry/csharp_api.yaml
@@ -1,0 +1,5 @@
+name: csharp_api
+backend:
+  port: 5000
+  domain: api.csharp.local
+compose_file: ../apps/csharp_api/docker-compose.yml

--- a/compose/app-registry/express_api.yaml
+++ b/compose/app-registry/express_api.yaml
@@ -1,0 +1,5 @@
+name: express_api
+backend:
+  port: 4000
+  domain: api.express.local
+compose_file: ../apps/express_api/docker-compose.yml

--- a/compose/app-registry/nest_api.yaml
+++ b/compose/app-registry/nest_api.yaml
@@ -1,0 +1,5 @@
+name: nest_api
+backend:
+  port: 4001
+  domain: api.nest.local
+compose_file: ../apps/nest_api/docker-compose.yml

--- a/docs/20-multi-language-backends.md
+++ b/docs/20-multi-language-backends.md
@@ -1,0 +1,99 @@
+# 20. Hosting Different Backend Languages
+
+## Purpose
+
+This guide demonstrates how to containerize and run various backend technologies with the hosting platform. Any language that can be packaged in a Docker image can be proxied by NGINX.
+
+The examples below show minimal setups for Python (FastAPI), Node.js (Express and NestJS), and C# (ASP.NET Core).
+
+---
+
+## Python FastAPI
+
+1. Create your application and add a `Dockerfile` similar to:
+   ```Dockerfile
+   FROM python:3.12-slim
+   WORKDIR /app
+   COPY . .
+   RUN pip install fastapi uvicorn
+   EXPOSE 8000
+   CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+   ```
+2. Define a compose file exposing the port:
+   ```yaml
+   services:
+     api:
+       build: .
+       ports:
+         - "8000:8000"
+   ```
+
+---
+
+## Node.js Express
+
+1. Basic server (`index.js`):
+   ```javascript
+   const express = require('express');
+   const app = express();
+   app.get('/', (req, res) => res.json({ message: 'Hello from Express' }));
+   app.listen(4000);
+   ```
+2. `Dockerfile`:
+   ```Dockerfile
+   FROM node:20-alpine
+   WORKDIR /app
+   COPY package.json ./
+   RUN npm install --production
+   COPY . .
+   EXPOSE 4000
+   CMD ["node", "index.js"]
+   ```
+
+---
+
+## Node.js NestJS
+
+1. Minimal `main.ts` using NestJS decorators.
+2. Build with TypeScript and run the compiled output.
+3. Compose file exposes port `4001` just like the Express example.
+
+---
+
+## C# ASP.NET Core
+
+1. Create a simple `Program.cs`:
+   ```csharp
+   var builder = WebApplication.CreateBuilder(args);
+   var app = builder.Build();
+   app.MapGet("/", () => Results.Json(new { message = "Hello from ASP.NET Core" }));
+   app.Run();
+   ```
+2. `Dockerfile` targeting .NET 8:
+   ```Dockerfile
+   FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+   WORKDIR /app
+   EXPOSE 5000
+
+   FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+   WORKDIR /src
+   COPY *.csproj ./
+   RUN dotnet restore
+   COPY . .
+   RUN dotnet publish -c Release -o /app/publish
+
+   FROM base AS final
+   WORKDIR /app
+   COPY --from=build /app/publish .
+   ENTRYPOINT ["dotnet", "csharp_api.dll"]
+   ```
+3. Compose file exposes `5000` for the proxy.
+
+---
+
+Once Docker images for these services are built and compose files are referenced in `compose/app-registry/*.yaml`, run:
+```bash
+python scripts/generate-nginx.py
+python scripts/launch_apps.py up
+```
+NGINX will proxy to each backend according to the registry configuration.

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -113,12 +113,12 @@ This platform allows you to host multiple fullstack applications by referencing 
    ```bash
    docker-compose up -d --build
    ```
-4. Start your apps using their own Compose files:
+4. Start your apps using their own Compose files or run them all via the helper script:
    ```bash
-   docker compose -f /path/to/your/app/docker-compose.yml up -d
+   python scripts/launch_apps.py up
    ```
 
-Apps will be reverse proxied by domain via NGINX.
+Apps will be reverse proxied by domain via NGINX. The platform targets Python (FastAPI), Node.js (Express/NestJS), and C# backends as first-class citizens.
 
 ## Requirements
 - Docker & Docker Compose

--- a/docs/hostingplan.md
+++ b/docs/hostingplan.md
@@ -41,10 +41,12 @@ hosting-server/
 ### 2. **Register External Apps**
 
 Each app gets a YAML file in `compose/app-registry/` that defines:
-- Name
-- Frontend port & domain
-- Backend port & domain
-- Path to the app’s `docker-compose.yml`
+  - Name
+  - Frontend port & domain
+  - Backend port & domain
+  - Path to the app’s `docker-compose.yml`
+
+Backends can be written in Python (FastAPI), Node.js (Express or NestJS), or C# using ASP.NET Core. As long as the app exposes a port via Docker Compose, the proxy can route to it.
 
 **Example:** `compose/app-registry/app1.yaml`
 ```yaml
@@ -82,11 +84,11 @@ This brings up only the platform itself.
 
 ### 5. **Launch the Apps (Externally)**
 
-Each app lives outside the host repo. Deploy it using its own compose file:
+Each app lives outside the host repo. You can deploy them individually or run them all via a helper script:
 ```bash
-docker compose -f /external/path/to/app1/docker-compose.yml up -d
+python scripts/launch_apps.py up
 ```
-Ensure ports match those defined in the app registry.
+The script reads the registry and executes `docker compose` for each referenced `compose_file`. Ensure ports match those defined in the registry.
 
 ---
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -30,6 +30,7 @@ This checklist defines the **build order** of the platform. Each item represents
 | 18 | Rust: Metrics Exporter | [18-metrics-exporter.md](./18-metrics-exporter.md) | [x] |
 
 | 19 | Rust: Custom CLI Tool | [19-custom-cli-tool.md](./19-custom-cli-tool.md) | [x] |
+| 20 | Multi-language Backends | [20-multi-language-backends.md](./20-multi-language-backends.md) | [ ] |
 
 ---
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -3,14 +3,42 @@ events { worker_connections 1024; }
 
 http {
 
+  
+
+  
+  upstream nest_api_backend {
+    server nest_api_backend:4001;
+  }
+  
+
+  
+
+  
+  server {
+    listen 80;
+    server_name api.nest.local;
+
+    location / {
+      proxy_pass http://nest_api_backend;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+    }
+  }
+  
+
+  
   upstream app1_frontend {
     server app1_frontend:3000;
   }
+  
 
+  
   upstream app1_backend {
     server app1_backend:8000;
   }
+  
 
+  
   server {
     listen 80;
     server_name app1.local;
@@ -21,7 +49,9 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
     }
   }
+  
 
+  
   server {
     listen 80;
     server_name api.app1.local;
@@ -32,5 +62,52 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
     }
   }
+  
+
+  
+
+  
+  upstream csharp_api_backend {
+    server csharp_api_backend:5000;
+  }
+  
+
+  
+
+  
+  server {
+    listen 80;
+    server_name api.csharp.local;
+
+    location / {
+      proxy_pass http://csharp_api_backend;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+    }
+  }
+  
+
+  
+
+  
+  upstream express_api_backend {
+    server express_api_backend:4000;
+  }
+  
+
+  
+
+  
+  server {
+    listen 80;
+    server_name api.express.local;
+
+    location / {
+      proxy_pass http://express_api_backend;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+    }
+  }
+  
 
 }

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -3,14 +3,19 @@ events { worker_connections 1024; }
 
 http {
 {% for app in apps %}
+  {% if app.frontend %}
   upstream {{ app.name }}_frontend {
     server {{ app.name }}_frontend:{{ app.frontend.port }};
   }
+  {% endif %}
 
+  {% if app.backend %}
   upstream {{ app.name }}_backend {
     server {{ app.name }}_backend:{{ app.backend.port }};
   }
+  {% endif %}
 
+  {% if app.frontend %}
   server {
     listen 80;
     server_name {{ app.frontend.domain }};
@@ -21,7 +26,9 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
     }
   }
+  {% endif %}
 
+  {% if app.backend %}
   server {
     listen 80;
     server_name {{ app.backend.domain }};
@@ -32,5 +39,6 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
     }
   }
+  {% endif %}
 {% endfor %}
 }

--- a/scripts/launch_apps.py
+++ b/scripts/launch_apps.py
@@ -1,0 +1,32 @@
+import os
+import subprocess
+import yaml
+
+REGISTRY_PATH = "compose/app-registry"
+
+def load_registry():
+    apps = []
+    for file in os.listdir(REGISTRY_PATH):
+        if file.endswith(".yaml"):
+            with open(os.path.join(REGISTRY_PATH, file)) as f:
+                apps.append(yaml.safe_load(f))
+    return apps
+
+def run_compose(app, action):
+    compose_file = app.get("compose_file")
+    if not compose_file:
+        return
+    cmd = ["docker", "compose", "-f", compose_file, action, "-d"]
+    subprocess.run(cmd, check=True)
+
+
+def main():
+    import sys
+    action = sys.argv[1] if len(sys.argv) > 1 else "up"
+    apps = load_registry()
+    for app in apps:
+        print(f"Running '{action}' for {app['name']}")
+        run_compose(app, action)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- extend NGINX template for optional frontend/backend
- add helper script `launch_apps.py` to run compose files from registry
- scaffold sample Express, NestJS and C# apps with compose files
- register new apps in app-registry
- document multi-language hosting and update usage instructions

## Testing
- `python -m py_compile scripts/launch_apps.py`
- `python -m py_compile scripts/generate-nginx.py`
- `python scripts/generate-nginx.py`
- `python scripts/launch_apps.py up` *(fails: docker compose not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d6f46b7408323b84ee7ebc769250b