### PR TITLE
Improve FastAPI hosting workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository contains a lightweight platform for hosting multiple fullstack a
 
 Sample backends are provided for FastAPI, Express, NestJS and ASP.NET to demonstrate that any Dockerised language can be integrated.
 
+The FastAPI example now includes a flexible `start.sh` script that reads environment variables (`PORT`, `WORKERS`, and `LOG_LEVEL`) and a `/health` endpoint for basic monitoring.
+
 ## Usage
 
 1. Add YAML files under `compose/app-registry/` describing each app's domains and ports.

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,22 +1,16 @@
 FROM python:3.12-slim
 
-# System setup
-RUN apt-get update && apt-get install -y curl && \
-    curl -sSL https://install.python-poetry.org | python3 - && \
-    ln -s ~/.local/bin/poetry /usr/local/bin/poetry
-
 WORKDIR /app
 
-# Copy lock + toml first for better cache use
-COPY pyproject.toml poetry.lock ./
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
 
-# Install dependencies
-RUN poetry config virtualenvs.create false && \
-    poetry install --no-root --no-interaction --no-ansi
-
-# Copy source last
 COPY . .
 
-EXPOSE 8000
+RUN chmod +x start.sh prestart.sh
 
-CMD ["poetry", "run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+ENV PORT=8000
+
+EXPOSE $PORT
+
+CMD ["./start.sh"]

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -3,6 +3,11 @@ import os
 
 app = FastAPI()
 
+
+@app.get("/health")
+async def health_check():
+    return {"status": "ok"}
+
 @app.get("/")
 async def read_root():
     env = os.environ.get("ENV", "development")

--- a/apps/api/prestart.py
+++ b/apps/api/prestart.py
@@ -1,0 +1,4 @@
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logging.info("Prestart tasks complete")

--- a/apps/api/prestart.sh
+++ b/apps/api/prestart.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+if [ -f /app/prestart.py ]; then
+  echo "Running prestart tasks..."
+  python /app/prestart.py
+fi
+

--- a/apps/api/start.sh
+++ b/apps/api/start.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+/app/prestart.sh
+
+export PORT=${PORT:-8000}
+export WORKERS=${WORKERS:-1}
+export LOG_LEVEL=${LOG_LEVEL:-info}
+
+exec uvicorn main:app --host 0.0.0.0 --port "$PORT" --workers "$WORKERS" --log-level "$LOG_LEVEL"

--- a/docs/03-dockerizing-api.md
+++ b/docs/03-dockerizing-api.md
@@ -21,12 +21,19 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
-EXPOSE 8000
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+RUN chmod +x start.sh prestart.sh
+ENV PORT=8000
+EXPOSE $PORT
+CMD ["./start.sh"]
 ```
 
 - `main:app` assumes the entry point is `main.py` with `app = FastAPI()`.
 - `requirements.txt` contains all Python dependencies.
+- `start.sh` launches Uvicorn using environment variables:
+  - `PORT` – port to bind (default `8000`)
+  - `WORKERS` – number of worker processes
+  - `LOG_LEVEL` – log verbosity
+- `prestart.sh` runs optional setup tasks before the server starts.
 
 ## Step-by-Step: Build and Run Locally
 
@@ -49,6 +56,7 @@ CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
    ```
 
    Visit [http://localhost:8000/docs](http://localhost:8000/docs) to view the interactive API docs.
+   A simple health check is available at `/health`.
 
 ## Integrating with Docker Compose
 

--- a/docs/20-multi-language-backends.md
+++ b/docs/20-multi-language-backends.md
@@ -14,10 +14,13 @@ The examples below show minimal setups for Python (FastAPI), Node.js (Express an
    ```Dockerfile
    FROM python:3.12-slim
    WORKDIR /app
+   COPY requirements.txt ./
+   RUN pip install --no-cache-dir -r requirements.txt
    COPY . .
-   RUN pip install fastapi uvicorn
-   EXPOSE 8000
-   CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+   RUN chmod +x start.sh prestart.sh
+   ENV PORT=8000
+   EXPOSE $PORT
+   CMD ["./start.sh"]
    ```
 2. Define a compose file exposing the port:
    ```yaml
@@ -26,7 +29,11 @@ The examples below show minimal setups for Python (FastAPI), Node.js (Express an
        build: .
        ports:
          - "8000:8000"
+       environment:
+         - PORT=8000
    ```
+
+`start.sh` reads the `PORT`, `WORKERS`, and `LOG_LEVEL` variables to control the Uvicorn server.
 
 ---
 


### PR DESCRIPTION
## Summary
- add prestart/start scripts for FastAPI example
- expose health check and configurable server options
- document new workflow for Python backends

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `bash -n apps/api/start.sh`
- `bash -n apps/api/prestart.sh`


------
https://chatgpt.com/codex/tasks/task_e_684d71cd17e88323ad191ed4548cb875