### PR TITLE
Add example app compose files and update hosting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ The FastAPI example now includes a flexible `start.sh` script that reads environ
    The script reads `compose/app-registry/*.yaml` and runs `docker compose` for each app.
 
 The apps will be accessible at the domains specified in the registry.
+For the built-in examples:
+- React frontend → `http://web.local`
+- FastAPI backend → `http://api.local`
 
 See the documentation in the `docs/` directory for detailed guides.
 

--- a/apps/api/docker-compose.yml
+++ b/apps/api/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.8"
+services:
+  api:
+    build: .
+    container_name: api
+    ports:
+      - "8000:8000"
+    environment:
+      - ENV=production

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -7,7 +7,6 @@ import uvicorn
 
 app = FastAPI()
 app.add_middleware(GZipMiddleware, minimum_size=1000)
-=======
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],

--- a/apps/csharp_api/Program.cs
+++ b/apps/csharp_api/Program.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddResponseCompression();
-=======
 builder.Services.AddHealthChecks();
 var app = builder.Build();
 app.UseResponseCompression();

--- a/apps/web/docker-compose.yml
+++ b/apps/web/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.8"
+services:
+  web:
+    build: .
+    container_name: web
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=production

--- a/compose/app-registry/api.yaml
+++ b/compose/app-registry/api.yaml
@@ -1,0 +1,5 @@
+name: api
+backend:
+  port: 8000
+  domain: api.local
+compose_file: ../apps/api/docker-compose.yml

--- a/compose/app-registry/web.yaml
+++ b/compose/app-registry/web.yaml
@@ -1,0 +1,5 @@
+name: web
+frontend:
+  port: 3000
+  domain: web.local
+compose_file: ../apps/web/docker-compose.yml

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -23,6 +23,22 @@ backend:
   domain: api.app1.local
 compose_file: /home/youruser/code/my-apps/app1/docker-compose.yml
 
+# compose/app-registry/web.yaml
+
+name: web
+frontend:
+  port: 3000
+  domain: web.local
+compose_file: ../apps/web/docker-compose.yml
+
+# compose/app-registry/api.yaml
+
+name: api
+backend:
+  port: 8000
+  domain: api.local
+compose_file: ../apps/api/docker-compose.yml
+
 # nginx/nginx.conf.template
 
 worker_processes 1;
@@ -119,6 +135,7 @@ This platform allows you to host multiple fullstack applications by referencing 
    ```
 
 Apps will be reverse proxied by domain via NGINX. The platform targets Python (FastAPI), Node.js (Express/NestJS), and C# backends as first-class citizens.
+For the provided React and FastAPI samples, browse to `http://web.local` and `http://api.local` once everything is running.
 
 The sample apps demonstrate hosting FastAPI (Python), Express and NestJS (Node.js),
 and an ASP.NET minimal API. Any Dockerised backend can be added to the registry

--- a/docs/hostingplan.md
+++ b/docs/hostingplan.md
@@ -96,8 +96,8 @@ The script reads the registry and executes `docker compose` for each referenced 
 ### 6. **Access the Apps**
 
 Once everything is running:
-- Open `http://app1.local` → frontend
-- Open `http://api.app1.local` → backend
+- Open `http://web.local` → React frontend
+- Open `http://api.local` → FastAPI backend
 
 To support custom domains or HTTPS, you'll configure DNS and SSL later.
 

--- a/services/static_file_proxy/Cargo.toml
+++ b/services/static_file_proxy/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 axum = { version = "0.7", features = ["macros"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs"] }
-tower-http = { version = "0.5", features = ["fs", "set-header"] }
 http = "1"
 tower-http = { version = "0.6", features = ["fs", "compression-gzip", "set-header"] }
 reqwest = { version = "0.12", features = ["rustls-tls"] }


### PR DESCRIPTION
## Summary
- fix leftover merge markers in FastAPI and C# example apps
- create docker-compose files for example React and FastAPI services
- register new `web` and `api` apps in the app registry
- update docs with example domains and registry snippets
- fix static file proxy build issues

## Testing
- `cargo check` for all Rust services


------
https://chatgpt.com/codex/tasks/task_e_684d91d7554c83238410c4462cf5fcf4