### PR TITLE
Add analytics capture and embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ For the built-in examples:
 - React frontend → `http://web.local`
 - FastAPI backend → `http://api.local`
 
+The stack now includes a Python-based **data_capture** service. It stores
+metrics from `metrics_exporter` in SQLite, embeds them with Ollama's
+`nomic-embed-text:v1.5` model, and persists vectors in a local Chroma database.
+
 See the documentation in the `docs/` directory for detailed guides.
 
 ## CLI

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,20 @@ services:
 
       - PROXY_PORT=8080
 
+  data_capture:
+    build: ./services/data_capture
+    container_name: data_capture
+    depends_on:
+      - metrics_exporter
+    volumes:
+      - ./data:/data
+    environment:
+      - SQLITE_PATH=/data/metrics.sqlite
+      - CHROMA_PATH=/data/chroma
+      - METRICS_URL=http://metrics_exporter:9300/metrics
+      - CAPTURE_INTERVAL_SECS=60
+      - CHROMA_COLLECTION=metrics
+
 
 volumes:
   db_data:

--- a/docs/21-data-capture.md
+++ b/docs/21-data-capture.md
@@ -1,0 +1,45 @@
+# 21. Data Capture and Vector Embedding
+
+## Purpose
+
+This service collects metrics from the stack, stores them in SQLite, and then
+embeds the records using Ollama's `nomic-embed-text:v1.5` model. Embeddings are
+stored in a local Chroma database. After a successful flush the SQLite table is
+cleared to avoid unbounded growth.
+
+## Key Features
+
+- Periodically fetches metrics from `metrics_exporter`.
+- Persists raw metrics in a SQLite database.
+- Generates embeddings via the running Ollama server.
+- Stores embeddings in a persistent Chroma collection.
+- Deletes processed rows after they are embedded.
+
+## Docker Compose Integration
+
+```yaml
+  data_capture:
+    build: ./services/data_capture
+    container_name: data_capture
+    depends_on:
+      - metrics_exporter
+    volumes:
+      - ./data:/data
+    environment:
+      - SQLITE_PATH=/data/metrics.sqlite
+      - CHROMA_PATH=/data/chroma
+      - METRICS_URL=http://metrics_exporter:9300/metrics
+      - CAPTURE_INTERVAL_SECS=60
+      - CHROMA_COLLECTION=metrics
+```
+
+## Requirements
+
+- Python 3
+- `requests`, `chromadb`, `ollama` packages
+- A running Ollama instance with the `nomic-embed-text:v1.5` model
+```
+ollama pull nomic-embed-text:v1.5
+```
+
+The Chroma database is created in the mounted volume path.

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -141,6 +141,10 @@ The sample apps demonstrate hosting FastAPI (Python), Express and NestJS (Node.j
 and an ASP.NET minimal API. Any Dockerised backend can be added to the registry
 following the same pattern.
 
+The platform also ships with a `data_capture` service which stores metrics in
+SQLite, embeds them with the `nomic-embed-text:v1.5` model via Ollama and writes
+the vectors to a Chroma database.
+
 ## Requirements
 - Docker & Docker Compose
 - Python (`pyyaml`, `jinja2`)

--- a/docs/hostingplan.md
+++ b/docs/hostingplan.md
@@ -110,6 +110,7 @@ To support custom domains or HTTPS, you'll configure DNS and SSL later.
 - 🧠 Build a CLI or UI for managing the registry
 - 📦 Add isolated DB containers or volumes per app
 - 📊 Monitoring + health checks for hosted apps
+- 📈 Capture metrics in SQLite and embed them with Ollama + Chroma
 
 ---
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -33,6 +33,7 @@ This checklist defines the **build order** of the platform. Each item represents
 
 
 | 20 | Multi-Language Backends | [20-multi-language-backends.md](./20-multi-language-backends.md) | [x] |
+| 21 | Data Capture & Embedding | [21-data-capture.md](./21-data-capture.md) | [x] |
 
 
 ---

--- a/services/data_capture/Dockerfile
+++ b/services/data_capture/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY main.py .
+CMD ["python", "main.py"]

--- a/services/data_capture/main.py
+++ b/services/data_capture/main.py
@@ -1,0 +1,65 @@
+import os
+import time
+import sqlite3
+import requests
+import ollama
+import chromadb
+
+DB_PATH = os.environ.get("SQLITE_PATH", "/data/metrics.sqlite")
+METRICS_URL = os.environ.get("METRICS_URL", "http://metrics_exporter:9300/metrics")
+CHROMA_PATH = os.environ.get("CHROMA_PATH", "/data/chroma")
+COLLECTION_NAME = os.environ.get("CHROMA_COLLECTION", "metrics")
+INTERVAL = int(os.environ.get("CAPTURE_INTERVAL_SECS", "60"))
+
+
+def init_db():
+    conn = sqlite3.connect(DB_PATH)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS metrics (id INTEGER PRIMARY KEY AUTOINCREMENT, ts TEXT, data TEXT)"
+    )
+    conn.commit()
+    return conn
+
+
+def capture_metrics(conn):
+    resp = requests.get(METRICS_URL, timeout=10)
+    resp.raise_for_status()
+    ts = time.strftime("%Y-%m-%dT%H:%M:%S")
+    conn.execute("INSERT INTO metrics (ts, data) VALUES (?, ?)", (ts, resp.text))
+    conn.commit()
+
+
+def embed_and_reset(conn, client):
+    cur = conn.execute("SELECT id, data FROM metrics")
+    rows = cur.fetchall()
+    if not rows:
+        return
+    ids = []
+    docs = []
+    for row_id, data in rows:
+        ids.append(str(row_id))
+        docs.append(data)
+    embeddings = [
+        ollama.embeddings(model="nomic-embed-text:v1.5", prompt=d)["embedding"]
+        for d in docs
+    ]
+    collection = client.get_or_create_collection(COLLECTION_NAME)
+    collection.upsert(documents=docs, ids=ids, embeddings=embeddings)
+    conn.execute("DELETE FROM metrics")
+    conn.commit()
+
+
+def main():
+    conn = init_db()
+    client = chromadb.PersistentClient(path=CHROMA_PATH)
+    while True:
+        try:
+            capture_metrics(conn)
+            embed_and_reset(conn, client)
+        except Exception as exc:
+            print(f"error: {exc}")
+        time.sleep(INTERVAL)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/data_capture/requirements.txt
+++ b/services/data_capture/requirements.txt
@@ -1,0 +1,3 @@
+requests
+chromadb
+ollama


### PR DESCRIPTION
## Summary
- integrate Python-based data_capture service
- embed metrics via ollama into Chroma
- wire data_capture into docker-compose
- document new service and update project docs

## Testing
- `python -m py_compile services/data_capture/main.py`
- `cargo build --release` for existing Rust services

------
https://chatgpt.com/codex/tasks/task_e_684d9a2fd5e0832383874426fd7578cb