### PR TITLE
Integrate Ollama embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ For the built-in examples:
 - FastAPI backend → `http://api.local`
 
 The stack now includes a Python-based **data_capture** service. It stores
-metrics from `metrics_exporter` in SQLite, embeds them with Ollama's
-`nomic-embed-text:v1.5` model, and persists vectors in a local Chroma database.
+metrics from `metrics_exporter` in SQLite and embeds them with Ollama's
+`nomic-embed-text:v1.5` model, persisting vectors in a local Chroma database.
+Embeddings are generated via a dedicated **ollama** container exposed on
+`http://ollama:11434`.
 
 See the documentation in the `docs/` directory for detailed guides.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,11 +109,20 @@ services:
 
       - PROXY_PORT=8080
 
+  ollama:
+    image: ollama/ollama:latest
+    container_name: ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+
   data_capture:
     build: ./services/data_capture
     container_name: data_capture
     depends_on:
       - metrics_exporter
+      - ollama
     volumes:
       - ./data:/data
     environment:
@@ -122,7 +131,9 @@ services:
       - METRICS_URL=http://metrics_exporter:9300/metrics
       - CAPTURE_INTERVAL_SECS=60
       - CHROMA_COLLECTION=metrics
+      - OLLAMA_HOST=http://ollama:11434
 
 
 volumes:
   db_data:
+  ollama_data:

--- a/docs/21-data-capture.md
+++ b/docs/21-data-capture.md
@@ -18,11 +18,20 @@ cleared to avoid unbounded growth.
 ## Docker Compose Integration
 
 ```yaml
+  ollama:
+    image: ollama/ollama:latest
+    container_name: ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+
   data_capture:
     build: ./services/data_capture
     container_name: data_capture
     depends_on:
       - metrics_exporter
+      - ollama
     volumes:
       - ./data:/data
     environment:
@@ -31,13 +40,14 @@ cleared to avoid unbounded growth.
       - METRICS_URL=http://metrics_exporter:9300/metrics
       - CAPTURE_INTERVAL_SECS=60
       - CHROMA_COLLECTION=metrics
+      - OLLAMA_HOST=http://ollama:11434
 ```
 
 ## Requirements
 
 - Python 3
 - `requests`, `chromadb`, `ollama` packages
-- A running Ollama instance with the `nomic-embed-text:v1.5` model
+- A running Ollama instance with the `nomic-embed-text:v1.5` model (provided by the `ollama` service)
 ```
 ollama pull nomic-embed-text:v1.5
 ```

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -141,9 +141,9 @@ The sample apps demonstrate hosting FastAPI (Python), Express and NestJS (Node.j
 and an ASP.NET minimal API. Any Dockerised backend can be added to the registry
 following the same pattern.
 
-The platform also ships with a `data_capture` service which stores metrics in
-SQLite, embeds them with the `nomic-embed-text:v1.5` model via Ollama and writes
-the vectors to a Chroma database.
+The platform also ships with `data_capture` and `ollama` services. Metrics are
+stored in SQLite, then embedded through the Ollama API using the
+`nomic-embed-text:v1.5` model, and finally persisted to a Chroma database.
 
 ## Requirements
 - Docker & Docker Compose


### PR DESCRIPTION
## Summary
- add new `ollama` service for embedding generation
- configure `data_capture` to use the Ollama API
- document the Ollama service and updated embedding workflow

## Testing
- `python -m py_compile services/data_capture/main.py`
- `cargo check` in services/metrics_exporter
- `docker-compose config`

------
https://chatgpt.com/codex/tasks/task_e_684d9de1f3e4832388bfdeebbce165de