### PR TITLE
Add initial Go support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Fullstack App Hosting Platform
 
-This repository contains a lightweight platform for hosting multiple fullstack applications. Each app defines its own Compose file externally and is reverse proxied through a single NGINX instance. The platform can proxy Python (FastAPI), Node.js (Express or NestJS), and even C# backends.
+This repository contains a lightweight platform for hosting multiple fullstack applications. Each app defines its own Compose file externally and is reverse proxied through a single NGINX instance. The platform can proxy Python (FastAPI), Node.js (Express or NestJS), C#, and now Go backends.
 
-Sample backends are provided for FastAPI, Express, NestJS and ASP.NET to demonstrate that any Dockerised language can be integrated.
+Sample backends are provided for FastAPI, Express, NestJS, ASP.NET, and a simple Go service to demonstrate that any Dockerised language can be integrated.
 
 The example apps now include compression middleware and request logging. The React frontend checks the API health endpoint from a configurable URL, and the static file proxy serves assets with long-lived caching headers.
 
@@ -35,6 +35,9 @@ metrics from `metrics_exporter` in SQLite and embeds them with Ollama's
 `nomic-embed-text:v1.5` model, persisting vectors in a local Chroma database.
 Embeddings are generated via a dedicated **ollama** container exposed on
 `http://ollama:11434`.
+
+The repository also introduces a Go-based **go_job_queue** service showcasing
+goroutines and channels for concurrent background processing.
 
 See the documentation in the `docs/` directory for detailed guides.
 

--- a/apps/go-api/Dockerfile
+++ b/apps/go-api/Dockerfile
@@ -1,0 +1,14 @@
+# Build stage
+FROM golang:1.21-alpine AS builder
+WORKDIR /app
+COPY go.mod .
+COPY main.go .
+RUN go build -o go-api
+
+# Final stage
+FROM alpine:latest
+WORKDIR /app
+COPY --from=builder /app/go-api /usr/local/bin/go-api
+EXPOSE 8080
+ENV PORT=8080
+CMD ["go-api"]

--- a/apps/go-api/docker-compose.yml
+++ b/apps/go-api/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.8"
+services:
+  go-api:
+    build: .
+    container_name: go-api
+    ports:
+      - "8080:8080"
+    environment:
+      - PORT=8080

--- a/apps/go-api/go.mod
+++ b/apps/go-api/go.mod
@@ -1,0 +1,3 @@
+module goapi
+
+go 1.21

--- a/apps/go-api/main.go
+++ b/apps/go-api/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "ok")
+	})
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Hello from Go")
+	})
+
+	log.Printf("Listening on :%s", port)
+	log.Fatal(http.ListenAndServe(":"+port, nil))
+}

--- a/compose/app-registry/go-api.yaml
+++ b/compose/app-registry/go-api.yaml
@@ -1,0 +1,5 @@
+name: go-api
+backend:
+  port: 8080
+  domain: go.local
+compose_file: ../apps/go-api/docker-compose.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,14 @@ services:
 
       - PROXY_PORT=8080
 
+  go_job_queue:
+    build: ./services/go_job_queue
+    container_name: go_job_queue
+    ports:
+      - "9001:9000"
+    environment:
+      - PORT=9000
+
   ollama:
     image: ollama/ollama:latest
     container_name: ollama

--- a/docs/20-multi-language-backends.md
+++ b/docs/20-multi-language-backends.md
@@ -98,6 +98,40 @@ The examples below show minimal setups for Python (FastAPI), Node.js (Express an
 
 ---
 
+## Go
+
+1. Minimal HTTP server (`main.go`):
+   ```go
+   package main
+   import (
+       "fmt"
+       "net/http"
+   )
+
+   func main() {
+       http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+           fmt.Fprintln(w, "Hello from Go")
+       })
+       http.ListenAndServe(":8080", nil)
+   }
+   ```
+2. `Dockerfile` using a multi-stage build:
+   ```Dockerfile
+   FROM golang:1.21-alpine AS builder
+   WORKDIR /app
+   COPY . .
+   RUN go build -o go-api
+
+   FROM alpine:latest
+   WORKDIR /app
+   COPY --from=builder /app/go-api /usr/local/bin/go-api
+   EXPOSE 8080
+   CMD ["go-api"]
+   ```
+3. Compose file exposes `8080` to the proxy.
+
+---
+
 Once Docker images for these services are built and compose files are referenced in `compose/app-registry/*.yaml`, run:
 ```bash
 python scripts/generate-nginx.py

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -39,6 +39,14 @@ backend:
   domain: api.local
 compose_file: ../apps/api/docker-compose.yml
 
+# compose/app-registry/go-api.yaml
+
+name: go-api
+backend:
+  port: 8080
+  domain: go.local
+compose_file: ../apps/go-api/docker-compose.yml
+
 # nginx/nginx.conf.template
 
 worker_processes 1;
@@ -134,11 +142,11 @@ This platform allows you to host multiple fullstack applications by referencing 
    python scripts/launch_apps.py up
    ```
 
-Apps will be reverse proxied by domain via NGINX. The platform targets Python (FastAPI), Node.js (Express/NestJS), and C# backends as first-class citizens.
+Apps will be reverse proxied by domain via NGINX. The platform targets Python (FastAPI), Node.js (Express/NestJS), C#, and Go backends as first-class citizens.
 For the provided React and FastAPI samples, browse to `http://web.local` and `http://api.local` once everything is running.
 
 The sample apps demonstrate hosting FastAPI (Python), Express and NestJS (Node.js),
-and an ASP.NET minimal API. Any Dockerised backend can be added to the registry
+an ASP.NET minimal API, and now a simple Go API. Any Dockerised backend can be added to the registry
 following the same pattern.
 
 The platform also ships with `data_capture` and `ollama` services. Metrics are

--- a/docs/hostingplan.md
+++ b/docs/hostingplan.md
@@ -14,7 +14,7 @@ This self-hosted platform is designed to serve as a lightweight PaaS. It allows 
 - ✅ Proxy frontend and backend domains using NGINX
 - ✅ Use a dynamic registry-based system to configure hosted apps
 - ✅ Keep the platform lightweight, modular, and extensible
-- ✅ Support backends written in Python, Node.js, and C#
+- ✅ Support backends written in Python, Node.js, C#, and Go
 
 ---
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -34,6 +34,7 @@ This checklist defines the **build order** of the platform. Each item represents
 
 | 20 | Multi-Language Backends | [20-multi-language-backends.md](./20-multi-language-backends.md) | [x] |
 | 21 | Data Capture & Embedding | [21-data-capture.md](./21-data-capture.md) | [x] |
+| 22 | Go Services & Utilities | [go.md](../go.md) | [ ] |
 
 
 ---

--- a/services/go_job_queue/Dockerfile
+++ b/services/go_job_queue/Dockerfile
@@ -1,0 +1,14 @@
+# Build stage
+FROM golang:1.21-alpine AS builder
+WORKDIR /app
+COPY go.mod .
+COPY main.go .
+RUN go build -o go-job-queue
+
+# Final stage
+FROM alpine:latest
+WORKDIR /app
+COPY --from=builder /app/go-job-queue /usr/local/bin/go-job-queue
+EXPOSE 9000
+ENV PORT=9000
+CMD ["go-job-queue"]

--- a/services/go_job_queue/README.md
+++ b/services/go_job_queue/README.md
@@ -1,0 +1,10 @@
+# Go Job Queue Service
+
+This service exposes a simple HTTP API to enqueue jobs and retrieve processed results.
+Jobs are processed concurrently by multiple workers using goroutines and a shared channel.
+
+## Endpoints
+- `POST /enqueue` with JSON `{ "data": "text" }` returns the job ID.
+- `GET /result?id=<ID>` returns the processed result or `202` if not ready.
+
+The number of workers and queue size are minimal for demonstration.

--- a/services/go_job_queue/go.mod
+++ b/services/go_job_queue/go.mod
@@ -1,0 +1,3 @@
+module gojobqueue
+
+go 1.21

--- a/services/go_job_queue/main.go
+++ b/services/go_job_queue/main.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+)
+
+type Job struct {
+	ID   int    `json:"id"`
+	Data string `json:"data"`
+}
+
+type Result struct {
+	ID        int    `json:"id"`
+	Processed string `json:"processed"`
+}
+
+var (
+	jobChan   chan Job
+	resultMap sync.Map
+	idCounter int
+)
+
+func worker() {
+	for job := range jobChan {
+		processed := fmt.Sprintf("processed: %s", job.Data)
+		resultMap.Store(job.ID, processed)
+	}
+}
+
+func enqueueHandler(w http.ResponseWriter, r *http.Request) {
+	var payload struct{ Data string }
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "bad payload", http.StatusBadRequest)
+		return
+	}
+	idCounter++
+	job := Job{ID: idCounter, Data: payload.Data}
+	jobChan <- job
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(job)
+}
+
+func resultHandler(w http.ResponseWriter, r *http.Request) {
+	idStr := r.URL.Query().Get("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		http.Error(w, "bad id", http.StatusBadRequest)
+		return
+	}
+	if value, ok := resultMap.Load(id); ok {
+		res := Result{ID: id, Processed: value.(string)}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(res)
+	} else {
+		http.Error(w, "not ready", http.StatusAccepted)
+	}
+}
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "9000"
+	}
+	workers := 4
+	jobChan = make(chan Job, 100)
+	for i := 0; i < workers; i++ {
+		go worker()
+	}
+
+	http.HandleFunc("/enqueue", enqueueHandler)
+	http.HandleFunc("/result", resultHandler)
+
+	log.Printf("Job queue listening on :%s", port)
+	log.Fatal(http.ListenAndServe(":"+port, nil))
+}


### PR DESCRIPTION
## Summary
- add a sample Go API with Dockerfile and compose file
- create Go job queue service showing goroutines
- register `go-api` in app registry and update generator docs
- document Go backend in multi-language guide and hosting docs
- update project goals and table of contents for Go support
- mention Go services in README
- include go_job_queue in docker-compose

## Testing
- `go build` in apps/go-api
- `go build` in services/go_job_queue
- `go test ./...` in apps/go-api and services/go_job_queue
- `cargo test` for log_watcher and backup_scheduler

------
https://chatgpt.com/codex/tasks/task_e_684dc8dafd2c832398c0acbf15605189