### PR TITLE
Add deployment UI and API

### DIFF
--- a/apps/platform-ui/Dockerfile
+++ b/apps/platform-ui/Dockerfile
@@ -1,0 +1,14 @@
+# Stage 1: build static assets
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package.json tsconfig.json vite.config.ts ./
+COPY src ./src
+COPY index.html ./
+RUN npm ci && npm run build
+
+# Stage 2: serve with nginx
+FROM nginx:1.27-alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 3001
+CMD ["nginx", "-g", "daemon off;"]

--- a/apps/platform-ui/docker-compose.yml
+++ b/apps/platform-ui/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.8"
+services:
+  platform-ui:
+    build: .
+    container_name: platform-ui
+    ports:
+      - "3001:3001"
+    environment:
+      - NODE_ENV=production

--- a/apps/platform-ui/index.html
+++ b/apps/platform-ui/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Platform UI</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/platform-ui/nginx.conf
+++ b/apps/platform-ui/nginx.conf
@@ -1,0 +1,13 @@
+server {
+    listen 3001;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types text/css application/javascript application/json image/svg+xml;
+    add_header Cache-Control "public, max-age=3600";
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/apps/platform-ui/package.json
+++ b/apps/platform-ui/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "platform-ui",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "start": "vite preview --port 3001"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "@types/node": "^20.10.6",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.0"
+  }
+}

--- a/apps/platform-ui/src/App.tsx
+++ b/apps/platform-ui/src/App.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+
+interface AppInfo {
+  name: string;
+}
+
+export function App() {
+  const base = import.meta.env.VITE_API_URL || '/api';
+  const [status, setStatus] = useState('Loading...');
+  const [apps, setApps] = useState<AppInfo[]>([]);
+
+  useEffect(() => {
+    fetch(`${base}/apps`)
+      .then((r) => (r.ok ? r.json() : Promise.reject()))
+      .then((data) => {
+        setApps(data.apps.map((n: string) => ({ name: n })));
+        setStatus('Ready');
+      })
+      .catch(() => setStatus('API unreachable'));
+  }, [base]);
+
+  const action = async (name: string, cmd: 'deploy' | 'stop') => {
+    setStatus(`${cmd}ing ${name}...`);
+    await fetch(`${base}/${cmd}/${name}`, { method: 'POST' });
+    setStatus('Done');
+  };
+
+  return (
+    <main>
+      <h1>Platform Deployments</h1>
+      <p>{status}</p>
+      <ul>
+        {apps.map((a) => (
+          <li key={a.name}>
+            {a.name}{' '}
+            <button onClick={() => action(a.name, 'deploy')}>Deploy</button>{' '}
+            <button onClick={() => action(a.name, 'stop')}>Stop</button>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/apps/platform-ui/src/ErrorBoundary.tsx
+++ b/apps/platform-ui/src/ErrorBoundary.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends React.Component<React.PropsWithChildren, ErrorBoundaryState> {
+  constructor(props: React.PropsWithChildren) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(err: unknown) {
+    console.error('ErrorBoundary caught', err);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <h1>Something went wrong.</h1>;
+    }
+    return this.props.children;
+  }
+}

--- a/apps/platform-ui/src/main.tsx
+++ b/apps/platform-ui/src/main.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { ErrorBoundary } from './ErrorBoundary';
+import { App } from './App';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
+  </React.StrictMode>
+);

--- a/apps/platform-ui/src/vite-env.d.ts
+++ b/apps/platform-ui/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/platform-ui/tsconfig.json
+++ b/apps/platform-ui/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}

--- a/apps/platform-ui/vite.config.ts
+++ b/apps/platform-ui/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3001,
+    proxy: {
+      '/api': {
+        target: process.env.API_PROXY_TARGET || 'http://localhost:8000',
+        changeOrigin: true,
+      },
+    },
+  },
+  build: { target: 'esnext' },
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -169,6 +169,17 @@ services:
     environment:
       - WS_PORT=9400
 
+  deployment_api:
+    build: ./services/deployment_api
+    container_name: deployment_api
+    volumes:
+      - .:/repo
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - REGISTRY_PATH=/repo/compose/app-registry
+    ports:
+      - "9500:8080"
+
 
 volumes:
   db_data:

--- a/docs/25-web-ui.md
+++ b/docs/25-web-ui.md
@@ -1,0 +1,75 @@
+# 25. Web Deployment Interface
+
+## Purpose
+
+This guide introduces a minimal web interface that allows users to deploy and stop applications from the hosting platform. The design is inspired by Vercel's dashboard, providing a simple list of apps and one-click actions to launch them via the new `deployment_api` service.
+
+---
+
+## Features
+
+- Display all registered apps from `compose/app-registry`.
+- Deploy or stop an app with a single button.
+- Show basic status messages returned from the API.
+
+---
+
+## System Architecture
+
+```
++--------------+      HTTP       +-----------------+    Docker Compose
+|  Platform UI |  <--------->   |  deployment_api  |  <---------------> host
++--------------+                 +-----------------+
+```
+
+1. The React based **Platform UI** calls the FastAPI **deployment_api**.
+2. The API reads the registry and runs `docker compose` commands on the host.
+3. NGINX continues to proxy traffic for running apps as before.
+
+---
+
+## Directory Structure
+
+```
+apps/
+  platform-ui/       # React frontend
+services/
+  deployment_api/    # FastAPI backend to run compose commands
+```
+
+---
+
+## Platform UI Usage
+
+1. Install dependencies and start in development mode:
+   ```bash
+   cd apps/platform-ui
+   npm install
+   npm run dev
+   ```
+   The UI runs on `http://localhost:3001` and proxies API calls to `deployment_api`.
+
+2. Build and run with Docker Compose:
+   ```bash
+   docker compose up -d deployment_api
+   npm run build
+   ```
+   After building, serve the static files with any web server or integrate it into your existing NGINX setup.
+
+---
+
+## deployment_api Service
+
+- **Endpoint:** `GET /apps` – list available app names.
+- **Endpoint:** `POST /deploy/{name}` – build and start an app.
+- **Endpoint:** `POST /stop/{name}` – stop an app and remove its containers.
+- The service mounts the repository directory and Docker socket so it can execute `docker compose` commands.
+
+---
+
+## Next Steps
+
+- Add authentication and per-user access controls.
+- Display real-time deployment logs in the UI.
+- Track deployment history for each app.
+

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -37,6 +37,7 @@ This checklist defines the **build order** of the platform. Each item represents
 | 22 | MongoDB Backup Service | [22-mongo-backup.md](./22-mongo-backup.md) | [x] |
 | 23 | WebSocket Broadcast Service | [23-websocket-broadcast.md](./23-websocket-broadcast.md) | [x] |
 | 24 | Go Services & Utilities | [go.md](../go.md) | [ ] |
+| 25 | Web Deployment Interface | [25-web-ui.md](./25-web-ui.md) | [ ] |
 
 
 ---

--- a/services/deployment_api/Dockerfile
+++ b/services/deployment_api/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY main.py .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/services/deployment_api/main.py
+++ b/services/deployment_api/main.py
@@ -1,0 +1,42 @@
+import os
+import subprocess
+import yaml
+from fastapi import FastAPI, HTTPException
+
+REGISTRY_PATH = os.environ.get("REGISTRY_PATH", "/repo/compose/app-registry")
+
+app = FastAPI(title="Deployment API")
+
+
+def load_registry():
+    apps = {}
+    for file in os.listdir(REGISTRY_PATH):
+        if file.endswith(".yaml"):
+            with open(os.path.join(REGISTRY_PATH, file)) as f:
+                data = yaml.safe_load(f)
+                if compose := data.get("compose_file"):
+                    apps[data["name"]] = compose
+    return apps
+
+
+@app.get("/apps")
+def list_apps():
+    return {"apps": list(load_registry().keys())}
+
+
+@app.post("/deploy/{app_name}")
+def deploy(app_name: str):
+    compose_file = load_registry().get(app_name)
+    if not compose_file:
+        raise HTTPException(status_code=404, detail="Unknown app")
+    subprocess.run(["docker", "compose", "-f", compose_file, "up", "-d", "--build"], check=True)
+    return {"status": "deployed", "app": app_name}
+
+
+@app.post("/stop/{app_name}")
+def stop(app_name: str):
+    compose_file = load_registry().get(app_name)
+    if not compose_file:
+        raise HTTPException(status_code=404, detail="Unknown app")
+    subprocess.run(["docker", "compose", "-f", compose_file, "down"], check=True)
+    return {"status": "stopped", "app": app_name}

--- a/services/deployment_api/requirements.txt
+++ b/services/deployment_api/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pyyaml


### PR DESCRIPTION
## Summary
- add minimal deployment API for launching compose apps
- create Platform UI React app to trigger deployments
- document the web deployment interface
- list new step in docs
- integrate deployment_api service in docker-compose

## Testing
- `pytest -q`
- `cd apps/platform-ui && npx tsc --noEmit`
- `cargo test` *(fails: could not find `Cargo.toml`)*

------
https://chatgpt.com/codex/tasks/task_e_684e438cccc88323af43175986dbbaf5